### PR TITLE
Make actuall use of the Azure login hint

### DIFF
--- a/artifacts/Application/planet9_custom_login/script/neptune.Script/Functions/logonAzure.script
+++ b/artifacts/Application/planet9_custom_login/script/neptune.Script/Functions/logonAzure.script
@@ -168,7 +168,10 @@ var AppCacheLogonAzure = {
             prompt: prompt,
             response_type: "code"
         };
-
+        if (loginHint) {
+            delete data.prompt
+            data.login_hint = loginHint
+        }
         return this._authUrl("authorize") + $.param(data);
     },
 


### PR DESCRIPTION
Make actually use of the AzureLogin `login_hint` param to have pre-selected login name and suppress login select screen. If the Azure account name doesn't exits the login select prompt will be shown anyway and must not be explicitly set.